### PR TITLE
add sphinx config html_last_updated_fmt to avoid None value in footer

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,4 +32,4 @@ html:
 sphinx:
   config:
     html_show_copyright: false
-    
+    html_last_updated_fmt: '%Y-%m-%d'


### PR DESCRIPTION
Hello,

I don't know why but as shown in #19 the Last Update footer is set to None when deployed on github pages.
It doesn't appear at all in the footer when building locally the book using `./build.sh` (with Sphinx v5.0.2 on Ubuntu 22).
Following [sphinx documentation](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_last_updated_fmt), it shouldn't appear at all if the value is None?

I propose to add `html_last_updated_fmt: '%Y-%m-%d'` in `_config .yml`

thank you,

Clement

