### PR TITLE
Added image metadata annotation workflow for OMERO

### DIFF
--- a/resources/blog_posts.yml
+++ b/resources/blog_posts.yml
@@ -94,3 +94,12 @@ resources:
   - bioimage analysis
   type: blog
   url: https://focalplane.biologists.com/2023/03/02/rescaling-images-and-pixel-anisotropy/
+
+- authors: Jens Wendt
+  name: User friendly Image metadata annotation tool/workflow for OMERO
+  tags:
+  - metadata
+  - workflow
+  - OMERO
+  type: forum post
+  url: https://forum.image.sc/t/user-friendly-image-metadata-annotation-tool-workflow-for-omero/87925/1


### PR DESCRIPTION
This recent post on forum.image.sc describes a tool and an example workflow for metadata annotation of bio-images using OMERO.