### PR TITLE
Add download statistics and zenodo link scripts

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -29,7 +29,6 @@ jobs:
     - name: Build the book
       run: |
         python scripts/generate_link_lists.py
-        python scripts/summary_download_statistics.py
         jupyter-book build docs/
 
     # Push the book's HTML to github-pages

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Build the book
       run: |
         python scripts/generate_link_lists.py
+        python scripts/summary_download_statistics.py
         jupyter-book build docs/
 
     # Push the book's HTML to github-pages

--- a/scripts/generate_link_lists.py
+++ b/scripts/generate_link_lists.py
@@ -290,7 +290,10 @@ def read_zenodo(record):
     import json
 
     record = record.replace("https://zenodo.org/", "")
+    record = record.replace("record/", "records/")
     url = "https://zenodo.org/api/" + record
+
+    print(url)
     
     # Download the file
     response = requests.get(url)

--- a/scripts/summary_download_statistics.py
+++ b/scripts/summary_download_statistics.py
@@ -5,34 +5,51 @@ import requests
 import json
 from generate_link_lists import read_zenodo, read_yaml_file, all_content
 import pandas as pd
+from pathlib import Path
 
 #define directory path
-directory_path = '../resources/'
+directory_path = 'resources/'
+
+#directory where the current script is located
+#current_dir = Path(__file__).parent
+
+#define path to 'resources' directory relative to current script
+#directory_path = current_dir.parent / 'resources'
 
 #collect all content in a list of dictionaries
 content = all_content(directory_path) 
 
 #create pandas Dataframe called download_statistics 
-download_statistics = pd.DataFrame(columns=['doi_url', 'downloads', 'unique_downloads', 'views', 'unique_views', 'version_downloads', 'version_unique_downloads', 'version_unique_views', 'version_views'])
+download_statistics = pd.DataFrame(columns=['file_id', 'downloads', 'unique_downloads', 'views', 'unique_views', 'version_downloads', 'version_unique_downloads', 'version_unique_views', 'version_views'])
 
 for entry in content['resources']:
+    urls = entry['url']
 
-    # if zenodo in url
-    if 'zenodo.org' in str(entry['url']):
+    #make urls a list if it is not already
+    if not type(urls) is list:
+            urls = [urls]
+    
+    for url in urls:
+        # if zenodo in url
+        if 'zenodo.org' in url:
 
-        #extract meta data of records in zenodo
-        zenodo = read_zenodo(str(entry['url']))
-        if 'stats' in zenodo.keys():
-            print(zenodo)
-            
-            #create new row entry
-            row_entry = {'doi_url': zenodo['doi_url'], 'downloads': zenodo['stats']['downloads'], 'unique_downloads': zenodo['stats']['unique_downloads'], 'views': zenodo['stats']['views'], 'unique_views': zenodo['stats']['unique_views'], 'version_downloads': zenodo['stats']['version_downloads'], 'version_unique_downloads': zenodo['stats']['version_unique_downloads'], 'version_unique_views': zenodo['stats']['version_unique_views'], 'version_views': zenodo['stats']['version_views']}
+            #extract meta data of records in zenodo
+            zenodo = read_zenodo(url)
 
-            # Create a data frame with the new row entry
-            df_entry = pd.DataFrame([row_entry])
+            if 'stats' in zenodo.keys():
+                
+                #zenodo metadata download statistics stored on per-file basis, so we need to access all files in the record using 'id' key
+                for file in zenodo['files']:
 
-            #concatenate the new DataFrame with the existing `download_statistics` DataFrame
-            download_statistics = pd.concat([download_statistics, df_entry], ignore_index=True)
-        
-#save pd dataframe as csv file
+                    # define row entry
+                    row_entry = {'file_id': file['id'], 'downloads': zenodo['stats']['downloads'], 'unique_downloads': zenodo['stats']['unique_downloads'], 'views': zenodo['stats']['views'], 'unique_views': zenodo['stats']['unique_views'], 'version_downloads': zenodo['stats']['version_downloads'], 'version_unique_downloads': zenodo['stats']['version_unique_downloads'], 'version_unique_views': zenodo['stats']['version_unique_views'], 'version_views': zenodo['stats']['version_views']}
+
+                    # Create a new DataFrame with the new row
+                    df_entry = pd.DataFrame([row_entry])
+
+                    # Concatenate the new DataFrame with the existing `download_statistics` DataFrame
+                    download_statistics = pd.concat([download_statistics, df_entry], ignore_index=True)
+                    print(download_statistics)
+
+
 download_statistics.to_csv('download_statistics.csv', index=False)

--- a/scripts/summary_download_statistics.py
+++ b/scripts/summary_download_statistics.py
@@ -8,7 +8,7 @@ import pandas as pd
 from pathlib import Path
 
 #define directory path
-directory_path = 'resources/'
+directory_path = './resources/'
 
 #directory where the current script is located
 #current_dir = Path(__file__).parent

--- a/scripts/summary_download_statistics.py
+++ b/scripts/summary_download_statistics.py
@@ -1,0 +1,38 @@
+#summarize download statistics
+
+#import statements
+import requests
+import json
+from generate_link_lists import read_zenodo, read_yaml_file, all_content
+import pandas as pd
+
+#define directory path
+directory_path = '../resources/'
+
+#collect all content in a list of dictionaries
+content = all_content(directory_path) 
+
+#create pandas Dataframe called download_statistics 
+download_statistics = pd.DataFrame(columns=['doi_url', 'downloads', 'unique_downloads', 'views', 'unique_views', 'version_downloads', 'version_unique_downloads', 'version_unique_views', 'version_views'])
+
+for entry in content['resources']:
+
+    # if zenodo in url
+    if 'zenodo.org' in str(entry['url']):
+
+        #extract meta data of records in zenodo
+        zenodo = read_zenodo(str(entry['url']))
+        if 'stats' in zenodo.keys():
+            print(zenodo)
+            
+            #create new row entry
+            row_entry = {'doi_url': zenodo['doi_url'], 'downloads': zenodo['stats']['downloads'], 'unique_downloads': zenodo['stats']['unique_downloads'], 'views': zenodo['stats']['views'], 'unique_views': zenodo['stats']['unique_views'], 'version_downloads': zenodo['stats']['version_downloads'], 'version_unique_downloads': zenodo['stats']['version_unique_downloads'], 'version_unique_views': zenodo['stats']['version_unique_views'], 'version_views': zenodo['stats']['version_views']}
+
+            # Create a data frame with the new row entry
+            df_entry = pd.DataFrame([row_entry])
+
+            #concatenate the new DataFrame with the existing `download_statistics` DataFrame
+            download_statistics = pd.concat([download_statistics, df_entry], ignore_index=True)
+        
+#save pd dataframe as csv file
+download_statistics.to_csv('download_statistics.csv', index=False)

--- a/scripts/summary_download_statistics.py
+++ b/scripts/summary_download_statistics.py
@@ -6,6 +6,7 @@ import json
 from generate_link_lists import read_zenodo, read_yaml_file, all_content
 import pandas as pd
 from pathlib import Path
+import datetime
 
 #define directory path
 directory_path = './resources/'
@@ -51,5 +52,11 @@ for entry in content['resources']:
                     download_statistics = pd.concat([download_statistics, df_entry], ignore_index=True)
                     print(download_statistics)
 
+#get current date
+date = datetime.datetime.now().strftime("%Y%m%d")
 
-download_statistics.to_csv('download_statistics.csv', index=False)
+#create filename
+filename = f'download_statistics_{date}.csv'
+
+#save download_statistics to CSV file with the new filename
+download_statistics.to_csv(filename, index=False)

--- a/scripts/zenodo_links_from_doi.py
+++ b/scripts/zenodo_links_from_doi.py
@@ -1,0 +1,37 @@
+#store zenodo links from doi
+
+import requests
+import json
+from generate_link_lists import read_doi, all_content
+
+#define directory path
+directory_path = '../resources/'
+
+#collect all content in a list of dictionaries
+content = all_content(directory_path) 
+
+for entry in content['resources']:
+    urls = entry['url']
+
+    #make urls a list if it is not already
+    if not type(urls) is list:
+            urls = [urls]
+            #print(urls)
+    
+    for url in urls:
+        
+        if 'doi.org' in url:
+
+            #extract meta data of records from doi.org
+            data = read_doi(url)
+            
+            #search for word zenodo in meta data because this is the zenodo-link we want to append to url
+            if 'zenodo.org' in str(data['values']):
+
+                 #check if zenodo is already in url
+                 if 'zenodo' in url:
+    
+                    #replace zenodo link with the new one but keep all other links
+                    entry['url'].remove(url)
+                    entry['url'].append(data['values'][1]['data']['value'])
+                    print(entry['url'])

--- a/scripts/zenodo_links_from_doi.py
+++ b/scripts/zenodo_links_from_doi.py
@@ -5,7 +5,7 @@ import json
 from generate_link_lists import read_doi, all_content
 
 #define directory path
-directory_path = '../resources/'
+directory_path = './resources/'
 
 #collect all content in a list of dictionaries
 content = all_content(directory_path) 


### PR DESCRIPTION
Hi all,

This PR adds two scripts: one to summarise download statistics and one to store zenodo links from DOI. Hereby, the corresponding Issue numbers can be found in individual commits.

closes #79 
closes #81 

Best,
Mara