### PR TITLE
Download stats

### DIFF
--- a/download_statistics/20240628.csv
+++ b/download_statistics/20240628.csv
@@ -1,0 +1,35 @@
+url,authors,downloads,unique_downloads,views,unique_views,version_downloads,version_unique_downloads,version_unique_views,version_views
+https://zenodo.org/record/4071471,"""Biernacka, Katarzyna and Bierwirth, Maik and Buchholz, Petra and Dolzycka, Dominika and Helbig, Kerstin and Neumann, Janna and Odebrecht, Carolin and Wiljes, Cord and Wuttke, Ulrike""",4545,3520,5800,5221,4525,3503,5196,5774
+https://zenodo.org/record/3490058,"""Biernacka, Katarzyna and Cortez, Katrin and Helbig, Kerstin""",109,101,177,159,107,99,154,172
+https://zenodo.org/record/6602101,"""Della Chiesa, Stefano""",1092,697,872,715,278,191,165,204
+https://zenodo.org/records/8323588,"""Schmidt, Christian and Bortolomeazzi, Michele and Boissonnet, Tom and Fortmann-Grote, Carsten and Dohle, Julia and Zentis, Peter and Kandpal, Niraj and Kunis, Susanne and Zobel, Thomas and Weidtkamp-Peters, Stefanie and Ferrando-May, Elisa""",3671,3175,2085,1930,3671,3175,1930,2085
+https://zenodo.org/records/2643411,"""Stephen Royle""",104,100,774,743,104,100,741,772
+https://zenodo.org/records/4334697,"""Floden, Evan and Di Tommaso, Paolo""",72,71,48,46,72,71,46,48
+https://zenodo.org/records/4328911,"""Bankhead, Peter""",172,160,50,48,171,159,48,50
+https://zenodo.org/records/4317149,"""Jordan, Kari and Kamvar, Zhian and Hodges, Toby""",31,29,52,49,31,29,49,52
+https://zenodo.org/records/10083555,"""Wetzker, Cornelia""",78,59,112,107,78,59,107,112
+https://zenodo.org/records/10815329,"""Haase, Robert""",304,228,320,300,253,187,260,273
+https://zenodo.org/records/10679054,"""Fazeli, Elnaz""",158,129,214,205,158,129,205,214
+https://zenodo.org/records/10654775,"""Haase, Robert""",178,153,393,358,73,68,229,255
+https://zenodo.org/records/10008465,"""Moore, Josh""",95,62,107,102,95,62,102,107
+https://zenodo.org/records/10972692,"""Haase, Robert""",162,117,208,186,157,113,174,192
+https://zenodo.org/records/10990107,"""Haase, Robert""",135,94,188,174,120,81,148,159
+https://zenodo.org/records/10970869,"""Haase, Robert""",91,77,114,108,91,77,108,114
+https://zenodo.org/records/11066250,"""Haase, Robert""",88,71,71,62,82,65,51,59
+https://zenodo.org/records/11473803,"""Kemmer, Isabel and Euro-BioImaging ERIC""",114,88,125,114,114,88,114,125
+https://zenodo.org/records/11474407,"""Kemmer, Isabel and Euro-BioImaging ERIC""",81,65,99,91,81,65,91,99
+https://zenodo.org/records/11548617,"""Zoccoler, Marcelo and Bekemeier, Simon and Boissonnet, Tom and Parker, Simon and Bertinetti, Luca and Gentzel, Marc and Massei, Riccardo and Wetzker, Cornelia""",531,414,206,151,531,414,151,206
+https://zenodo.org/records/11265038,"""Pape, Constantin""",17,10,18,14,17,10,14,18
+https://zenodo.org/records/11107798,"""Voigt, Pia and Hundt, Carolin""",46,29,64,59,46,29,59,64
+https://zenodo.org/records/10942559,"""Della Chiesa, Stefano""",35,19,43,37,35,19,37,43
+https://zenodo.org/records/10816895,"""Haase, Robert""",62,50,71,65,62,50,65,71
+https://zenodo.org/records/4461261,"""Hesse, Elfi and Deinert, Jan-Christoph and Löschen, Christian""",280,253,505,483,277,250,481,503
+https://zenodo.org/records/11472148,"""Wünsche, Stephan""",29,22,52,50,29,22,50,52
+https://zenodo.org/records/11396199,"""Voigt, Pia""",27,24,58,56,27,24,56,58
+https://zenodo.org/records/4748510,"""Wünsche, Stephan and Voigt, Pia""",243,218,429,385,122,111,151,159
+https://zenodo.org/records/4630788,"""Voigt, Pia and Weiner, Barbara""",337,304,497,468,162,145,183,193
+https://zenodo.org/records/4748534,"""Voigt, Pia and Weiner, Barbara""",270,236,339,311,107,96,107,118
+https://zenodo.org/records/3778431,"""Weiner, Barbara and Wünsche, Stephan and Kühne, Stefan and Voigt, Pia and Frericks, Sebastian and Hoffmann, Clemens and Elze, Romy and Gey, Ronny""",1728,1447,2067,1753,1677,1412,1624,1909
+https://zenodo.org/records/11109616,"""Fuchs, Vanessa Aphaia Fiona and Schmidt, Christian and Boissonnet, Tom""",182,168,115,109,182,168,109,115
+https://zenodo.org/record/7018929,"""Kunis, Susanne""",26,19,113,106,26,19,104,111
+https://zenodo.org/records/8329306,"""Kunis, Susanne""",59,48,62,58,56,45,55,59


### PR DESCRIPTION
Hi @marabuuu ,

I modified your script for the download stats a bit and it would be great if you could review my changes. 

* I am no longer storing the file_id as identifier, but the url instead, because Zenodo doesn't offer the number of downloads per file. 
* I'm also storing the author names so that we can search for colleagues later more easily.
* Furthermore, I modified where the csv file is saved: in a folder where we can collect many of the CSV files over time.

Let me know what you think!

Best,
Robert