### PR TITLE
add tag statistics notebook

### DIFF
--- a/scripts/tag_statistics.ipynb
+++ b/scripts/tag_statistics.ipynb
@@ -1,0 +1,450 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2bc34237-e6c6-4d97-85f1-49ae9680be3d",
+   "metadata": {},
+   "source": [
+    "# Tag statistics\n",
+    "In this notebook we demonstrate how to retrieve our link collection as pandas DataFrame and how show which tags are used and how often."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "58de6710-4b1c-431d-92dd-ce2d49566384",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Intel MKL WARNING: Support of Intel(R) Streaming SIMD Extensions 4.2 (Intel(R) SSE4.2) enabled only processors has been deprecated. Intel oneAPI Math Kernel Library 2025.0 will require Intel(R) Advanced Vector Extensions (Intel(R) AVX) instructions.\n",
+      "Intel MKL WARNING: Support of Intel(R) Streaming SIMD Extensions 4.2 (Intel(R) SSE4.2) enabled only processors has been deprecated. Intel oneAPI Math Kernel Library 2025.0 will require Intel(R) Advanced Vector Extensions (Intel(R) AVX) instructions.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "from generate_link_lists import load_dataframe\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee616d91-4f5e-4a39-aa03-c3795f8ba128",
+   "metadata": {},
+   "source": [
+    "## Data import and cleaning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5d00e9fb-283c-406d-8740-5c74de0bb851",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Adding materials.yml\n",
+      "Adding workflow-tools.yml\n",
+      "Adding youtube_channels.yml\n",
+      "Adding blog_posts.yml\n",
+      "Adding papers.yml\n",
+      "Adding events.yml\n",
+      "Adding nfdi4bioimage.yml\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = load_dataframe(\"../resources/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5bdaa873-dc3c-44ef-a8e8-216577be4068",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>license</th>\n",
+       "      <th>name</th>\n",
+       "      <th>tags</th>\n",
+       "      <th>type</th>\n",
+       "      <th>url</th>\n",
+       "      <th>authors</th>\n",
+       "      <th>description</th>\n",
+       "      <th>num_downloads</th>\n",
+       "      <th>publication_date</th>\n",
+       "      <th>fingerprint</th>\n",
+       "      <th>event_date</th>\n",
+       "      <th>event_location</th>\n",
+       "      <th>doi</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>cc-by-4.0</td>\n",
+       "      <td>RDM4Mic Presentations</td>\n",
+       "      <td>[research data management]</td>\n",
+       "      <td>collection</td>\n",
+       "      <td>https://github.com/German-BioImaging/RDM4mic/t...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>ODC BY 1.0</td>\n",
+       "      <td>BioImage Informatics Index Training Materials</td>\n",
+       "      <td>[bioimage analysis]</td>\n",
+       "      <td>collection</td>\n",
+       "      <td>https://biii.eu/training-material</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>[CC BY 4.0, BSD 3-clause]</td>\n",
+       "      <td>BioImage Analysis Notebooks</td>\n",
+       "      <td>[python, bioimage analysis]</td>\n",
+       "      <td>[book, notebook]</td>\n",
+       "      <td>https://haesleinhuepf.github.io/BioImageAnalys...</td>\n",
+       "      <td>Robert Haase et al.</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>cc-by-4.0</td>\n",
+       "      <td>Introduction to Bioimage Analysis</td>\n",
+       "      <td>[python, imagej, bioimage analysis]</td>\n",
+       "      <td>[book, notebook]</td>\n",
+       "      <td>https://bioimagebook.github.io/index.html</td>\n",
+       "      <td>Pete Bankhead</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     license                                           name  \\\n",
+       "0                  cc-by-4.0                          RDM4Mic Presentations   \n",
+       "1                 ODC BY 1.0  BioImage Informatics Index Training Materials   \n",
+       "2  [CC BY 4.0, BSD 3-clause]                    BioImage Analysis Notebooks   \n",
+       "3                  cc-by-4.0              Introduction to Bioimage Analysis   \n",
+       "\n",
+       "                                  tags              type  \\\n",
+       "0           [research data management]        collection   \n",
+       "1                  [bioimage analysis]        collection   \n",
+       "2          [python, bioimage analysis]  [book, notebook]   \n",
+       "3  [python, imagej, bioimage analysis]  [book, notebook]   \n",
+       "\n",
+       "                                                 url              authors  \\\n",
+       "0  https://github.com/German-BioImaging/RDM4mic/t...                  NaN   \n",
+       "1                  https://biii.eu/training-material                  NaN   \n",
+       "2  https://haesleinhuepf.github.io/BioImageAnalys...  Robert Haase et al.   \n",
+       "3          https://bioimagebook.github.io/index.html        Pete Bankhead   \n",
+       "\n",
+       "  description  num_downloads publication_date fingerprint event_date  \\\n",
+       "0         NaN            NaN              NaN         NaN        NaN   \n",
+       "1         NaN            NaN              NaN         NaN        NaN   \n",
+       "2         NaN            NaN              NaN         NaN        NaN   \n",
+       "3         NaN            NaN              NaN         NaN        NaN   \n",
+       "\n",
+       "  event_location  doi  \n",
+       "0            NaN  NaN  \n",
+       "1            NaN  NaN  \n",
+       "2            NaN  NaN  \n",
+       "3            NaN  NaN  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acb07743-b794-4e36-b90e-6005b81b7342",
+   "metadata": {},
+   "source": [
+    "## Determine unique tags"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "12cae70f-ccf0-439f-a278-e42567fc25d0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['Bioimage analysis', 'CellPose', 'CellProfiler', 'DataPLANT',\n",
+       "       'Deep Learning', 'FAIR', 'FAIR-principles', 'FLIM', 'Fiji', 'GPU',\n",
+       "       'Image Data Management', 'ImageJ Macro', 'Large Language Models',\n",
+       "       'Licensing', 'Microscopy image analysis', 'NFDI4BIOIMAGE',\n",
+       "       'NFDI4BioImage', 'NFDI4Bioimage', 'OMERO', 'Open Access', 'Python',\n",
+       "       'Pytorch', 'QUAREO-LIMI', 'R', 'Research Data Management',\n",
+       "       'TU DRESDEN', 'TU Dresden', 'Zarr', 'arc',\n",
+       "       'artificial intelligence', 'big data', 'bio-image analysis',\n",
+       "       'bioimage analysis', 'bioimage data', 'bioinformatics',\n",
+       "       'cellprofiler', 'citing', 'clesperanto', 'conda', 'dask',\n",
+       "       'data analysis', 'data protection', 'data science',\n",
+       "       'data stewardship', 'deep learning', 'deployment',\n",
+       "       'diffusion models', 'elastix', 'fiji', 'git', 'hackathon',\n",
+       "       'i3dbio', 'image registration', 'image segmentation', 'imagej',\n",
+       "       'itk', 'licensing', 'machine learning', 'mamba', 'meta data',\n",
+       "       'metadata', 'microscopy image analysis', 'napari', 'neubias',\n",
+       "       'nfdi4bioimage', 'notebook', 'notebooks', 'omero', 'open science',\n",
+       "       'python', 'research data management', 'segmentation', 'sharing',\n",
+       "       'teaching', 'workflow', 'workflow engine', 'zenodo'], dtype='<U25')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lists = [t for t in df['tags'].tolist() if t not in ['nan']]\n",
+    "\n",
+    "all_tags = str(lists)\n",
+    "\n",
+    "long_list = []\n",
+    "\n",
+    "for l in lists:\n",
+    "    if isinstance(l, list):\n",
+    "        long_list += l\n",
+    "\n",
+    "list_of_tags = np.unique(long_list)\n",
+    "list_of_tags"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bda8c3b-f641-41ca-8f2c-9a591227b73b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Count occurences"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f3821daa-bcfc-49af-bdd4-290bd8380e58",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "tag_stats = {}\n",
+    "\n",
+    "for t in list_of_tags:\n",
+    "    count = len(all_tags.split(\"'\" + t + \"'\")) - 1\n",
+    "    tag_stats[t] = count"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "008419af-45b7-45f0-a471-1fa831c5e8e5",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Tag statistics\n",
+    "Here we will print out the tags we observed, with number of occurence descending ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "890b8112-d928-491e-af36-eabc561c5eca",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bioimage analysis: 119\n",
+      "research data management: 74\n",
+      "python: 39\n",
+      "artificial intelligence: 26\n",
+      "neubias: 26\n",
+      "Python: 22\n",
+      "NFDI4BioImage: 20\n",
+      "omero: 18\n",
+      "FAIR-principles: 16\n",
+      "imagej: 16\n",
+      "napari: 12\n",
+      "workflow engine: 12\n",
+      "Bioimage analysis: 7\n",
+      "sharing: 7\n",
+      "meta data: 6\n",
+      "bio-image analysis: 5\n",
+      "deep learning: 5\n",
+      "licensing: 4\n",
+      "CellProfiler: 3\n",
+      "bioinformatics: 3\n",
+      "segmentation: 3\n",
+      "teaching: 3\n",
+      "Deep Learning: 2\n",
+      "Fiji: 2\n",
+      "Research Data Management: 2\n",
+      "citing: 2\n",
+      "conda: 2\n",
+      "data protection: 2\n",
+      "data stewardship: 2\n",
+      "mamba: 2\n",
+      "microscopy image analysis: 2\n",
+      "CellPose: 1\n",
+      "DataPLANT: 1\n",
+      "FAIR: 1\n",
+      "FLIM: 1\n",
+      "GPU: 1\n",
+      "Image Data Management: 1\n",
+      "ImageJ Macro: 1\n",
+      "Large Language Models: 1\n",
+      "Licensing: 1\n",
+      "Microscopy image analysis: 1\n",
+      "NFDI4BIOIMAGE: 1\n",
+      "NFDI4Bioimage: 1\n",
+      "OMERO: 1\n",
+      "Open Access: 1\n",
+      "Pytorch: 1\n",
+      "QUAREO-LIMI: 1\n",
+      "R: 1\n",
+      "TU DRESDEN: 1\n",
+      "TU Dresden: 1\n",
+      "Zarr: 1\n",
+      "arc: 1\n",
+      "big data: 1\n",
+      "bioimage data: 1\n",
+      "cellprofiler: 1\n",
+      "clesperanto: 1\n",
+      "dask: 1\n",
+      "data analysis: 1\n",
+      "data science: 1\n",
+      "deployment: 1\n",
+      "diffusion models: 1\n",
+      "elastix: 1\n",
+      "fiji: 1\n",
+      "git: 1\n",
+      "hackathon: 1\n",
+      "i3dbio: 1\n",
+      "image registration: 1\n",
+      "image segmentation: 1\n",
+      "itk: 1\n",
+      "machine learning: 1\n",
+      "metadata: 1\n",
+      "nfdi4bioimage: 1\n",
+      "notebook: 1\n",
+      "notebooks: 1\n",
+      "open science: 1\n",
+      "workflow: 1\n",
+      "zenodo: 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "sorted_tag_stats = dict(sorted(tag_stats.items(), key=lambda item: item[1], reverse=True))\n",
+    "\n",
+    "for key, value in sorted_tag_stats.items():\n",
+    "    print(f\"{key}: {value}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b41ca81-33e9-4465-b1e8-dd3c8249be97",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This adds [a notebook](https://github.com/NFDI4BIOIMAGE/training/blob/7045d4888217d6b73c53080ba42d020475dd41fd/scripts/tag_statistics.ipynb) for visualizing tag statistics - this might be useful for #99 . We can for example see that a tag "NFDI4BioImage" exists 20 times, and those exist too:
NFDI4BIOIMAGE: 1
NFDI4Bioimage: 1
nfdi4bioimage: 1

Hence, forcing all tags lower case could be a solution for example.