### PR TITLE
auto-import from our Zenodo community

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ docs/29_algorithm_validation/solution for exercise - metrics to investigate segm
 docs/22_feature_extraction/blobs_analysis.csv
 
 Untitled*
+notebooks/generate_link_lists.py

--- a/notebooks/import_from_zenodo_communities.ipynb
+++ b/notebooks/import_from_zenodo_communities.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4a41efb5-2f4a-41dd-98ba-eeecf01fdb68",
+   "metadata": {},
+   "source": [
+    "# Importing new entries from Zenodo communities\n",
+    "This notebook allows to import entries from Zenodo communities. It does not re-import entries that are already in our database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "22ccdd0e-5d18-448d-a343-1ab634771d26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "import bia_bob\n",
+    "import shutil\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7065b8ba-f726-41f0-ab49-48c9767fcda1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'./generate_link_lists.py'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# workaround: Until our utilities are a python library, we need to copy it here.\n",
+    "shutil.copy('../scripts/generate_link_lists.py', './generate_link_lists.py')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a1863536-3d4e-4144-a86e-92eff0cca25a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from generate_link_lists import load_dataframe\n",
+    "from generate_link_lists import update_yaml_file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f6c69566-1d52-4ec0-8733-2cc11e002cac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "token = os.getenv('ZENODO_API_KEY')\n",
+    "community = 'nfdi4bioimage'\n",
+    "\n",
+    "response = requests.get('https://zenodo.org/api/records',\n",
+    "                        params={'communities': community,\n",
+    "                                'access_token': token})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecd9050d-8dcd-4b69-9d1f-00fa1a37db80",
+   "metadata": {},
+   "source": [
+    "## That's what's listed in the community"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "efa9ffa0-159c-4996-a6bd-c5e1f4197c2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "online_data = response.json()\n",
+    "hits = online_data[\"hits\"][\"hits\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1c59f531-ab9d-480a-81a2-7e5dbb9f8609",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "25"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(hits)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "28cbcc3a-a43c-47ee-b249-30032957411a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['https://zenodo.org/records/11548617',\n",
+       " 'https://zenodo.org/records/11501662',\n",
+       " 'https://zenodo.org/records/11350689',\n",
+       " 'https://zenodo.org/records/11235513',\n",
+       " 'https://zenodo.org/records/11109616',\n",
+       " 'https://zenodo.org/records/11031747',\n",
+       " 'https://zenodo.org/records/10939520',\n",
+       " 'https://zenodo.org/records/10886750',\n",
+       " 'https://zenodo.org/records/10808486',\n",
+       " 'https://zenodo.org/records/10793700',\n",
+       " 'https://zenodo.org/records/10730424',\n",
+       " 'https://zenodo.org/records/10687659',\n",
+       " 'https://zenodo.org/records/10389955',\n",
+       " 'https://zenodo.org/records/10083555',\n",
+       " 'https://zenodo.org/records/10008465',\n",
+       " 'https://zenodo.org/records/8414319',\n",
+       " 'https://zenodo.org/records/8349563',\n",
+       " 'https://zenodo.org/records/8340248',\n",
+       " 'https://zenodo.org/records/8329306',\n",
+       " 'https://zenodo.org/records/8139354',\n",
+       " 'https://zenodo.org/records/8070038',\n",
+       " 'https://zenodo.org/records/8019760',\n",
+       " 'https://zenodo.org/records/7928333',\n",
+       " 'https://zenodo.org/records/7890311',\n",
+       " 'https://zenodo.org/records/7394675']"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "urls = [u[\"links\"][\"self_html\"] for u in hits]\n",
+    "urls"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "658e8be1-37bd-4830-8e0d-4a6d6b79452d",
+   "metadata": {},
+   "source": [
+    "## Checking what we already have"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1bba931f-1766-4b4c-b700-9550efdc0fec",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Adding blog_posts.yml\n",
+      "Adding events.yml\n",
+      "Adding imported.yml\n",
+      "Adding materials.yml\n",
+      "Adding nfdi4bioimage.yml\n",
+      "Adding papers.yml\n",
+      "Adding workflow-tools.yml\n",
+      "Adding youtube_channels.yml\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = load_dataframe(\"../resources/\")\n",
+    "\n",
+    "all_urls = str(df[\"url\"].tolist())\n",
+    "#all_urls"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5183ae2c-5144-4bff-a08f-d7a81f89ccef",
+   "metadata": {},
+   "source": [
+    "## Identifying entries we are missing yet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4d91a514-be3f-4629-85fa-fda961ebe275",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['https://zenodo.org/records/11501662',\n",
+       " 'https://zenodo.org/records/11350689',\n",
+       " 'https://zenodo.org/records/11235513',\n",
+       " 'https://zenodo.org/records/11031747',\n",
+       " 'https://zenodo.org/records/10939520',\n",
+       " 'https://zenodo.org/records/10886750',\n",
+       " 'https://zenodo.org/records/10808486',\n",
+       " 'https://zenodo.org/records/10793700',\n",
+       " 'https://zenodo.org/records/10730424',\n",
+       " 'https://zenodo.org/records/10687659',\n",
+       " 'https://zenodo.org/records/10389955',\n",
+       " 'https://zenodo.org/records/8414319',\n",
+       " 'https://zenodo.org/records/8349563',\n",
+       " 'https://zenodo.org/records/8340248',\n",
+       " 'https://zenodo.org/records/8139354',\n",
+       " 'https://zenodo.org/records/8070038',\n",
+       " 'https://zenodo.org/records/8019760',\n",
+       " 'https://zenodo.org/records/7928333',\n",
+       " 'https://zenodo.org/records/7890311',\n",
+       " 'https://zenodo.org/records/7394675']"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_urls = []\n",
+    "for url in urls:\n",
+    "    if url not in all_urls:\n",
+    "        new_urls.append(url)\n",
+    "\n",
+    "new_urls"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11fe5ad3-b68f-46cb-b9d6-3c9e6875cb64",
+   "metadata": {},
+   "source": [
+    "## Saving new entries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "4eee8bc1-9d9e-481c-b3ac-5867407eed96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('../resources/imported.yml', 'a') as file:\n",
+    "    for url in new_urls:\n",
+    "        file.write(\"- url: \" + url + '\\n')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c3e92c51-0b07-4b6b-a095-91b79252f96c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://zenodo.org/api/records/11548617\n",
+      "https://zenodo.org/api/records/11501662\n",
+      "https://zenodo.org/api/records/11350689\n",
+      "https://zenodo.org/api/records/11235513\n",
+      "https://zenodo.org/api/records/11031747\n",
+      "https://zenodo.org/api/records/10939520\n",
+      "https://zenodo.org/api/records/10886750\n",
+      "https://zenodo.org/api/records/10808486\n",
+      "https://zenodo.org/api/records/10793700\n",
+      "https://zenodo.org/api/records/10730424\n",
+      "https://zenodo.org/api/records/10687659\n",
+      "https://zenodo.org/api/records/10389955\n",
+      "https://zenodo.org/api/records/8414319\n",
+      "https://zenodo.org/api/records/8349563\n",
+      "https://zenodo.org/api/records/8340248\n",
+      "https://zenodo.org/api/records/8139354\n",
+      "https://zenodo.org/api/records/8070038\n",
+      "https://zenodo.org/api/records/8019760\n",
+      "https://zenodo.org/api/records/7928333\n",
+      "https://zenodo.org/api/records/7890311\n",
+      "https://zenodo.org/api/records/7394675\n"
+     ]
+    }
+   ],
+   "source": [
+    "update_yaml_file(\"../resources/imported.yml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fa55de8-b51a-45ce-934c-75c090166dab",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/resources/imported.yml
+++ b/resources/imported.yml
@@ -1,0 +1,397 @@
+resources:
+- authors: Zoccoler, Marcelo, Bekemeier, Simon, Boissonnet, Tom, Parker, Simon, Bertinetti,
+    Luca, Gentzel, Marc, Massei, Riccardo, Wetzker, Cornelia
+  description: 'The workshop introduced key topics of research data management (RDM)
+    and the implementation thereof on a life science campus. Internal and external
+    experts of RDM including scientists that apply chosen software tools presented
+    the basic concepts and their implementation to a broad audience.&nbsp;
+
+    Talks covered general aspects of data handling and sorting, naming conventions,
+    data storage repositories and archives, licensing of material, data and code management
+    using git, data protection particularly regarding patient data and in genome sequencing
+    and more. Two data management concepts and exemplary tools were highlighted in
+    particular, being electronic lab notebooks with eLabFTW and the bio-image management
+    software OMERO. Those were chosen because of three aspects: the large benefit
+    of these management tools for a life science campus, their free availability as
+    open source tools with the option of contribution of required functionalities
+    and first existing use cases on campus already supported by CMCB/PoL IT.
+
+    Two talks by Robert Haase (ScaDS.AI/ Uni Leipzig) and Robert M&uuml;ller (Kontaktstelle
+    Forschungsdaten, TU Dresden with contributions from Denise D&ouml;rfel) that opened
+    the symposium were shared independently:
+
+    https://zenodo.org/records/11382341
+
+    https://zenodo.org/records/11261115
+
+    The workshop organization was funded by the CMCB/PoL Networking Grant and supported
+    by the consortium NFDI4BIOIMAGE (funded by DFG grant number NFDI 46/1, project
+    number 501864659).'
+  license: cc-by-4.0
+  name: 'From Paper to Pixels: Navigation through your Research Data - presentations
+    of speakers'
+  num_downloads: 544
+  publication_date: '2024-06-10'
+  url:
+  - https://zenodo.org/records/11548617
+  - https://doi.org/10.5281/zenodo.11548617
+- authors: Massei, Riccardo, Schmidt, Christian, Bortolomeazzi, Michele, Thoennissen,
+    Julia, Bumberger, Jan, Dickscheid, Timo, Mallm, Jan-Philipp, Ferrando-May, Elisa
+  description: Germany&rsquo;s National Research Data Infrastructure (NFDI) aims to
+    establish a sustained, cross-disciplinary research data management (RDM) infrastructure
+    that enables researchers to handle FAIR (findable, accessible, interoperable,
+    reusable) data. While&nbsp;FAIR principles have been&nbsp;adopted by funders,
+    policymakers, and publishers, their practical implementation remains an ongoing
+    effort. In the field of bio-imaging, harmonization of&nbsp;data formats, metadata
+    ontologies, and open data repositories is necessary&nbsp;to achieve FAIR data.&nbsp;The
+    NFDI4BIOIMAGE was established&nbsp;to address these issues and&nbsp;develop tools
+    and best practices to facilitate FAIR microscopy and image analysis data in alignment
+    with international community activities. The&nbsp;consortium operates through
+    its Data Stewards team to provide expertise and direct support to help overcome
+    RDM challenges. The three Helmholtz Centers in NFDI4BIOIMAGE aim to collaborate
+    closely with other centers and initiatives, such as HMC, Helmholtz AI, and HIP.
+    Here we present NFDI4BIOIMAGE&rsquo;s work and its significance for research in
+    Helmholtz and beyond
+  license: cc-by-4.0
+  name: The role of Helmholtz Centers in NFDI4BIOIMAGE - A national consortium enhancing
+    FAIR data management for microscopy and bioimage analysis
+  num_downloads: 25
+  publication_date: '2024-06-06'
+  url:
+  - https://zenodo.org/records/11501662
+  - https://doi.org/10.5281/zenodo.11501662
+- authors: Massei, Riccardo, Bortolomeazzi, Michele, Schmidt, Christian
+  description: 'Here we share the material used in a workshop held on May 13th, 2024,
+    at the German Cancer Research Center in Heidelberg (on-premise)
+
+    Description:Microscopy experiments generate information-rich, multi-dimensional
+    data, allowing us to investigate biological processes at high spatial and temporal
+    resolution. Image processing and analysis is a standard procedure to retrieve
+    quantitative information from biological imaging. Due to the complex nature of
+    bioimaging files that often come in proprietary formats, it can be challenging
+    to organize, structure, and annotate bioimaging data throughout a project. Data
+    often needs to be moved between collaboration partners, transformed into open
+    formats, processed with a variety of software tools, and exported to smaller-sized
+    images for presentation. The path from image acquisition to final publication
+    figures with quantitative results must be documented and reproducible.
+
+    In this workshop, participants learn how to use OMERO to organize their data and
+    enrich the bioimage data with structured metadata annotations.We also focus on
+    image analysis workflows in combination with OMERO based on the Fiji/ImageJ software
+    and using Jupyter Notebooks. In the last part, we explore how OMERO can be used
+    to create publication figures and prepare bioimage data for publication in a suitable
+    repository such as the Bioimage Archive.
+
+    Module 1&nbsp;(9 am - 10.15 am):&nbsp;Basics of OMERO, data structuring and annotation
+
+    Module 2&nbsp;(10.45 am - 12.45 pm):&nbsp;OMERO and Fiji
+
+    Module 3&nbsp;(1.45 pm - 3.45 pm):&nbsp;OMERO and Jupyter Notebooks
+
+    Module 4&nbsp;(4.15 pm - 6. pm):&nbsp;Publication-ready figures and data with
+    OMERO
+
+    The target group for this workshopThis workshop is directed at researchers at
+    all career levels who plan to or have started to use OMERO for their microscopy
+    research data management.&nbsp;We encourage the workshop participants to bring
+    example data from their research to discuss suitable metadata annotation for their
+    everyday practice.
+
+    Prerequisites:Users should bring their laptops and have access to the internet
+    through one of the following options:- eduroam- institutional WiFi- VPN connection
+    to their institutional networks to access OMERO
+
+    Who are the trainers?
+
+    Dr. Riccardo Massei (Helmholtz-Center for Environmental Research, UFZ, Leipzig)
+    - Data Steward for Bioimaging Data in NFDI4BIOIMAGE
+
+    Dr. Michele Bortolomeazzi (DKFZ, Single cell Open Lab, bioimage data specialist,
+    bioinformatician, staff scientist in the NFDI4BIOIMAGE project)
+
+    Dr. Christian Schmidt (Science Manager for Research Data Management in Bioimaging,
+    German Cancer Research Center, Heidelberg, Project Coordinator of the NFDI4BIOIMAGE
+    project)'
+  license: cc-by-4.0
+  name: '[Workshop] Bioimage data management and analysis with OMERO'
+  num_downloads: 116
+  publication_date: '2024-05-13'
+  url:
+  - https://zenodo.org/records/11350689
+  - https://doi.org/10.5281/zenodo.11350689
+- authors: Moore, Josh, Kunis, Susanne
+  description: Poster presented at the European Light Microscopy Initiative meeting
+    in Liverpool (https://www.elmi2024.org/)
+  license: cc-by-4.0
+  name: '[ELMI 2024]  AI''s Dirty Little Secret: Without
+
+    FAIR Data, It''s Just Fancy Math'
+  num_downloads: 34
+  publication_date: '2024-05-21'
+  url:
+  - https://zenodo.org/records/11235513
+  - https://doi.org/10.5281/zenodo.11235513
+- authors: Fortmann-Grote, Carsten
+  description: This presentation was given at the 2nd MPG-NFDI Workshop on April 18th.
+  license: cc-by-4.0
+  name: NFDI4BIOIMAGE
+  num_downloads: 59
+  publication_date: '2024-04-22'
+  url:
+  - https://zenodo.org/records/11031747
+  - https://doi.org/10.5281/zenodo.11031747
+- authors: Schmidt, Christian
+  description: Short Talk about the NFDI4BIOIMAGE consortium presented at the RDM
+    in (Bio-)Medicine Information Event on April 10th, 2024, organized C&sup3;RDM
+    &amp; ZB MED.
+  license: cc-by-4.0
+  name: '[Short Talk] NFDI4BIOIMAGE - A consortium in the National Research Data Infrastructure'
+  num_downloads: 35
+  publication_date: '2024-04-10'
+  url:
+  - https://zenodo.org/records/10939520
+  - https://doi.org/10.5281/zenodo.10939520
+- authors: Margineanu, Anca, Stringari, Chiara, Zoccoler, Marcelo, Wetzker, Cornelia
+  description: The presentations introduce open-source software to read in, visualize
+    and analyse fluorescence lifetime imaging microscopy (FLIM) raw data developed
+    for life scientists. The slides were presented at German Bioimaging (GerBI) FLIM
+    Workshop held February 26 to 29 2024 at the Biomedical Center of LMU M&uuml;nchen
+    by Anca Margineanu, Chiara Stringari and Conni Wetzker.&nbsp;
+  license: cc-by-4.0
+  name: A Glimpse of the Open-Source FLIM Analysis Software Tools FLIMfit, FLUTE and
+    napari-flim-phasor-plotter
+  num_downloads: 163
+  publication_date: '2024-03-27'
+  url:
+  - https://zenodo.org/records/10886750
+  - https://doi.org/10.5281/zenodo.10886750
+- authors: Fortmann-Grote, Carsten
+  license: cc-by-4.0
+  name: Linked (Open) Data for Microbial Population Biology
+  num_downloads: 109
+  publication_date: '2024-03-12'
+  url:
+  - https://zenodo.org/records/10808486
+  - https://doi.org/10.5281/zenodo.10808486
+- authors: Massei, Riccardo
+  description: 'Results of the project "Conversion of KNIME image analysis workflows
+    to Galaxy" during the Hackathon "Image Analysis in Galaxy" (Freiburg 26 Feb -
+    01 Mar 2024)
+
+    &nbsp;'
+  license: cc-by-4.0
+  name: Hackaton Results - Conversion of KNIME image analysis workflows to Galaxy
+  num_downloads: 30
+  publication_date: '2024-03-07'
+  url:
+  - https://zenodo.org/records/10793700
+  - https://doi.org/10.5281/zenodo.10793700
+- authors: "Fuchs, Vanessa Aphaia Fiona, Wendt, Jens, M\xFCller, Maximilian, Ahmadi,\
+    \ Mohsen, Massei, Riccardo, Wetzker, Cornelia"
+  description: The Data Steward Team of the NFDI4BIOIMAGE consortium presents themselves
+    and the services (including the Helpdesk) that we offer.
+  license: cc-by-4.0
+  name: Who you gonna call? - Data Stewards to the rescue
+  num_downloads: 68
+  publication_date: '2024-03-01'
+  url:
+  - https://zenodo.org/records/10730424
+  - https://doi.org/10.5281/zenodo.10730424
+- authors: Moore, Josh, Waagmeester, Andra, Hettne, Kristina, Wolstencroft, Katherine,
+    Kunis, Susanne
+  description: 'In 2005, the first version of OMERO stored RDF natively. However,
+    just a year after the 1.0 release of RDF, performance considerations led to the
+    development of a more traditional SQL approach for OMERO. A binary protocol makes
+    it possible to query and retrieve metadata but the resulting information cannot
+    immediately be combined with other sources. This is the adventure of rediscovering
+    the benefit of RDF triples as a -- if not the -- common exchange mechanism.
+
+    &nbsp;
+
+    This poster was presented at SWAT4HCLS in Leiden, NL, 2024 as Poster 54. See https://www.swat4ls.org/workshops/leiden2024
+    for more information.'
+  license: cc-by-4.0
+  name: RDF as a bridge to domain-platforms like OMERO, or There and back again.
+  num_downloads: 83
+  publication_date: '2024-02-26'
+  url:
+  - https://zenodo.org/records/10687659
+  - https://doi.org/10.5281/zenodo.10687659
+- authors: NFDI4BIOIMAGE Consortium
+  description: 'Figure 10. Data flow to obtain a multimodal data structure (mmDS)
+    with an overarching graph database (MUGDAT).
+
+    from NFDI Grant Application, "National Research Data Infrastructure for Microscopy
+    and Bioimage Analysis" (NFDI4BIOIMAGE)'
+  license: cc-by-4.0
+  name: 'Section 5.3 "Task Area 3: Multimodal data linking and integration" Figure
+    10'
+  num_downloads: 2
+  publication_date: '2021-11-04'
+  url:
+  - https://zenodo.org/records/10389955
+  - https://doi.org/10.5281/zenodo.10389955
+- authors: Massei, Riccardo
+  description: NFDI4BIOIMAGE is a consortium within the framework of the National
+    Research Data Infrastructure (NFDI) in Germany. In this talk, the consortium and
+    the contribution to the work programme by the Helmholtz Centre&nbsp;for Environmental
+    Research (UFZ) in Leipzig are outlined.
+  license: cc-by-4.0
+  name: 'NFDI4BIOIMAGE - National Research Data Infrastructure for Microscopy and
+    BioImage Analysis [conference talk: The Pelagic Imaging Consortium meets Helmholtz
+    Imaging, 5.10.2023, Hamburg]'
+  num_downloads: 33
+  publication_date: '2023-10-06'
+  url:
+  - https://zenodo.org/records/8414319
+  - https://doi.org/10.5281/zenodo.8414319
+- authors: "St\xF6ter, Torsten, Gottschall, Tobias, Schrader, Andrea, Zentis, Peter,\
+    \ Valencia-Schneider, Monica, Kandpal, Niraj, Zuschratter, Werner, Schauss, Astrid,\
+    \ Dickscheid, Timo, M\xFChlhaus, Timo, von Suchodoletz, Dirk"
+  description: Interdisciplinary collaboration and integration of large and diverse
+    datasets are becoming increasingly important. Answering complex research questions
+    requires combining and analysing multimodal datasets. Research data management
+    follows the FAIR principles making data findable, accessible, interoperable, and
+    reusable. However, there are challenges in capturing the entire research cycle
+    and contextualizing data according, not only for the DataPLANT and NFDI4BIOIMAGE
+    communities. To address these challenges, DataPLANT developed a data structure
+    called Annotated Research Context (ARC). The Brain Imaging Data Structure (BIDS)
+    originated from the neuroimaging community extended for microscopic image data.
+    Both concepts provide standardised and file system based data storage structures
+    for organising and sharing research data accompanied with metadata. We exemplarily
+    compare the ARC and BIDS designs and propose structural and metadata mapping.
+  license: cc-by-4.0
+  name: Combining the BIDS and ARC Directory Structures for Multimodal Research Data
+    Organization
+  num_downloads: 159
+  publication_date: '2023-09-12'
+  url:
+  - https://zenodo.org/records/8349563
+  - https://doi.org/10.5281/zenodo.8349563
+- authors: Moore, Joshua Allen
+  description: 'For decades, the sharing of large N-dimensional datasets has posed
+    issues across multiple domains. Interactively accessing terabyte-scale data has
+    previously required significant server resources to properly prepare cropped or
+    down-sampled representations on the fly. Now, a cloud-native chunked format easing
+    this burden has been adopted in the bioimaging domain for standardization. The
+    format &mdash; Zarr &mdash; is potentially of interest for other consortia and
+    sections of NFDI.
+
+
+    Full text is available in the proceedings at&nbsp;https://www.tib-op.org/ojs/index.php/CoRDI/article/view/285'
+  license: cc-by-4.0
+  name: '[CORDI 2023] Zarr:  A Cloud-Optimized Storage for Interactive Access of Large
+    Arrays'
+  num_downloads: 132
+  publication_date: '2023-09-13'
+  url:
+  - https://zenodo.org/records/8340248
+  - https://doi.org/10.5281/zenodo.8340248
+- authors: Weischer, Sarah, Wendt, Jens, Zobel, Thomas
+  description: In this workshop a fully integrated data analysis solutions employing
+    OMERO and commonly applied image analysis tools (e.g., CellProfiler, Fiji) using
+    existing python interfaces (OMERO Python language bindings, ezOmero, Cellprofiler
+    Python API) is presented.
+  license: cc-by-4.0
+  name: High throughput & automated data analysis and data management workflow with
+    Cellprofiler and OMERO
+  num_downloads: 4
+  publication_date: '2023-07-12'
+  url:
+  - https://zenodo.org/records/8139354
+  - https://doi.org/10.5281/zenodo.8139354
+- authors: Stefanie Weidtkamp-Peters
+  description: Slideshow from the online Kick-Off event of NFDI4BIOIMAGE on June 20th.
+  license: cc-by-4.0
+  name: NFDI4BIOIMAGE - National Research Data Infrastructure for Microscopy and BioImage
+    Analysis - Online Kick-Off 2023
+  num_downloads: 89
+  publication_date: '2023-06-22'
+  url:
+  - https://zenodo.org/records/8070038
+  - https://doi.org/10.5281/zenodo.8070038
+- authors: Moore. Joshua Allen, Gay, Guillaume, Hartley, Matthew, Wolstencroft, Katherine
+  description: Figures created collaboratively by the presenters&nbsp;of the Data
+    Management and Analysis session of ELMI2023 (https://elmi2023.eu/) for their presentations.
+    They represent an idealized metro through which data (&quot;the passengers&quot;)
+    travel between various solutions (&quot;the stops&quot;) within bioimaging (&quot;BioImage
+    Town&quot;), but also connecting to IT solutions, metadata, and other areas, though
+    of course the real situation is much more complicated. Working together, we should
+    be able to the improve the number of easy-to-use, performant, and complete solutions
+    through&nbsp;BioImage Town for the benefit of the community.
+  license: cc-by-4.0
+  name: '[ELMI2023] BioImage Town (BIT) FAIR Data Metro Map'
+  num_downloads: 605
+  publication_date: '2023-06-09'
+  url:
+  - https://zenodo.org/records/8019760
+  - https://doi.org/10.5281/zenodo.8019760
+- authors: Moore, Joshua Allenm, Kunis, Susanne
+  description: 'Poster presented at&nbsp;Semantic Web Applications and Tools for Health
+    Care and Life Sciences (SWAT4HCLS 2023), Feb 13--16, 2023, Basel, Switzerland.
+
+
+    Abstract:&nbsp;NFDI4BIOIMAGE is a newly established German consortium dedicated
+    to the FAIR representation of biological imaging data. A key deliverable is the
+    definition of a semantically-compatible FAIR image object integrating RDF metadata
+    with web-compatible storage of large n-dimensional binary data in OME-Zarr. We
+    invite feedback from and collaboration with other endeavors during the soon-to-begin
+    5 year funding period.'
+  license: cc-by-4.0
+  name: '[SWAT4HCLS 2023] NFDI4BIOIMAGE: Perspective for a national bioimage standard'
+  num_downloads: 103
+  publication_date: '2023-05-12'
+  url:
+  - https://zenodo.org/records/7928333
+  - https://doi.org/10.5281/zenodo.7928333
+- authors: Stefanie Weidtkamp-Peters, Janina Hanne, Christian Schmidt
+  description: 'Oral presentation, 32nd MoMAN &quot;From Molecules to Man&quot; Seminar,
+    Ulm, online. Monday February 6th, 2023
+
+
+    Abstract:
+
+
+    Research data management is essential in nowadays research, and one of the big
+    opportunities to accelerate collaborative and innovative scientific projects.
+    To achieve this goal, all our data needs to be FAIR (findable, accessible, interoperable,
+    reproducible). For data acquired on microscopes, however, a common ground for
+    FAIR data sharing is still to be established. Plenty of work on file formats,
+    data bases, and training needs to be performed to highlight the value of data
+    sharing and exploit its potential for bioimaging data.
+
+
+    In this presentation, Stefanie Weidtkamp-Peters will introduce the challenges
+    for bioimaging data management, and the necessary steps to achieve data FAIRification.
+    German BioImaging - GMB e.V., together with other institutions, contributes to
+    this endeavor. Janina Hanne will present how the network of imaging core facilities,
+    research groups and industry partners is key to the German bioimaging community&rsquo;s
+    aligned collaboration toward FAIR bioimaging data. These activities have paved
+    the way for two data management initiatives in Germany: I3D:bio (Information Infrastructure
+    for BioImage Data) and NFDI4BIOIMAGE, a consortium of the National Research Data
+    Infrastructure. Christian Schmidt will introduce the goals and measures of these
+    initiatives to the benefit of imaging scientist&rsquo;s work and everyday practice.
+    &nbsp;'
+  license: cc-by-4.0
+  name: A journey to FAIR microscopy data
+  num_downloads: 54
+  publication_date: '2023-05-03'
+  url:
+  - https://zenodo.org/records/7890311
+  - https://doi.org/10.5281/zenodo.7890311
+- authors: NFDI4BIOIMAGE Consortium
+  description: 'Figure 8. A FAIR-IO bundle combines the necessary acquisition and
+    provenance metadata together with multi-resolution, chunked binary data in a single
+    cloud-compatible format for simplified sharing and re-use.
+
+
+    from NFDI Grant Application, &quot;National Research Data Infrastructure for Microscopy
+    and Bioimage Analysis&quot; (NFDI4BIOIMAGE)'
+  license: cc-by-4.0
+  name: 'Section 5.1 "Task Area 1: Image (meta)data formats and standardization)"
+    Figure 8'
+  num_downloads: 9
+  publication_date: '2021-11-04'
+  url:
+  - https://zenodo.org/records/7394675
+  - https://doi.org/10.5281/zenodo.7394675


### PR DESCRIPTION
I'm adding a [Jupyter notebook](https://github.com/NFDI4BIOIMAGE/training/blob/b934d5e79020fd28c662e774a5627dbfe248aaff/notebooks/import_from_zenodo_communities.ipynb) and an "imported.yml" file. The notebook automatically imported all entries from our [Zenodo community](https://zenodo.org/communities/nfdi4bioimage).

When the notebook is executed next time, it will not re-import entries. It will just add those which we were missing yet.

@SeverusYixin would you mind reviewing this PR? Let me know what you think!