### PR TITLE
Auto add zenodo entries

### DIFF
--- a/.github/workflows/auto-add-zenodo-entries.yml
+++ b/.github/workflows/auto-add-zenodo-entries.yml
@@ -1,0 +1,35 @@
+name: auto-add-zenodo-entries
+
+on:
+  issues:
+    types: opened
+
+jobs:
+  respond:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Print issue number
+      run: |  
+        echo "Issue Number - ${{ github.event.issue.number }}"
+        echo "Repository Name - ${{ github.repository }}"
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run Python
+      env:
+        GITHUB_API_KEY: "${{ secrets.GITHUB_TOKEN }}"
+        GITHUB_RUN_ID: "${{ github.run_id }}"
+      run: |
+        python scripts/auto-add-zenodo-entry.py ${{ github.repository }}" ${{ github.event.issue.number }}"

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -4,7 +4,9 @@ This repository contains lists of training materials. It is extensible using git
 
 # Quick contributing short-cut:
 
-If you're too busy to enter everything in detail yourself, please just create a [github issue](https://github.com/NFDI4BIOIMAGE/training/issues) with a link to the materials you want to include in our list. We can take of all the details.
+If you're too busy to enter everything in detail yourself, please just create a [github issue](https://github.com/NFDI4BIOIMAGE/training/issues) with a link to the materials you want to include in our list. 
+We can take of all the details.
+If it is a link to a zenodo record, please only paste that link into the text field and no additional explanation. These links are processed automatically then.
 
 ## What to contribute
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ sphinx-book-theme<1.0.0
 matplotlib
 numpy
 pandas
+pygithub
+toolz
+

--- a/scripts/_github_utilities.py
+++ b/scripts/_github_utilities.py
@@ -1,0 +1,206 @@
+import os
+from functools import lru_cache
+
+@lru_cache(maxsize=1)
+def get_github_repository(repository):
+    """
+    Get the GitHub repository object.
+
+    Parameters
+    ----------
+    repository : str
+        The full name of the GitHub repository (e.g., "username/repo-name").
+
+    Returns
+    -------
+    github.Repository.Repository
+        The GitHub repository object.
+    """
+    from github import Github
+    access_token = os.getenv('GITHUB_API_KEY')
+
+    # Create a PyGithub instance using the access token
+    g = Github(access_token)
+
+    # Get the repository object
+    return g.get_repo(repository)
+
+def get_issue_body(repository, issue):
+    """
+    Retrieve the body of a specific GitHub issue.
+
+    Parameters
+    ----------
+    repository : str
+        The full name of the GitHub repository (e.g., "username/repo-name").
+    issue : int
+        The issue number to retrieve the conversation for.
+
+    Returns
+    -------
+    str
+        The issue body.
+    """
+    print(f"-> get_conversation_on_issue({repository}, {issue})")
+
+    repo = get_github_repository(repository)
+
+    # Get the issue by number
+    issue_obj = repo.get_issue(issue)
+
+    # Get the body as a string
+    return issue_obj.body
+
+def write_file(repository, branch_name, file_path, new_content, commit_message="Update file"):
+    """
+    Modifies or creates a specified file with new content and saves the changes in a new git branch.
+    The name of the new branch is returned.
+
+    Parameters
+    ----------
+    repository : str
+        The full name of the GitHub repository (e.g., "username/repo-name").
+    file_path : str
+        A file path within the repository to change the contents of.
+    new_content : str
+        Text content that should be written into the file.
+    commit_message : str, optional
+        The commit message for the changes. Default is "Update file".
+
+    Returns
+    -------
+    str
+        The name of the branch where the changed file is stored.
+    """
+    print(f"-> write_file_in_new_branch({repository}, {branch_name}, {file_path}, ...)")
+
+    # Authenticate with GitHub
+    repo = get_github_repository(repository)
+
+    # Commit the changes
+    if check_if_file_exists(repository, branch_name, file_path):
+        file = get_file_in_repository(repository, branch_name, file_path)
+        repo.update_file(file.path, commit_message, new_content, file.sha, branch=branch_name)
+    else:
+        repo.create_file(file_path, commit_message, new_content, branch=branch_name)
+
+    return f"File {file_path} successfully created in repository {repository} branch {branch_name}."
+
+
+@lru_cache(maxsize=1)
+def get_file_in_repository(repository, branch_name, file_path):
+    """
+    Helper function to prevent multiple calls to the GitHub API for the same file.
+
+    Parameters
+    ----------
+    repository : str
+        The full name of the GitHub repository (e.g., "username/repo-name").
+    branch_name : str
+        The name of the branch to get the file content from.
+    file_path : str
+        The path of the file in the repository.
+
+    Returns
+    -------
+    github.ContentFile.ContentFile
+        The content file object of the specified file.
+    """
+    print("loading file content...", file_path)
+    repo = get_github_repository(repository)
+    return repo.get_contents(file_path, ref=branch_name)
+    
+
+def create_branch(repository, parent_branch="main"):
+    """
+    Creates a new branch in a given repository, derived from an optionally specified parent_branch and returns the name of the new branch.
+
+    Parameters
+    ----------
+    repository : str
+        The full name of the GitHub repository (e.g., "username/repo-name").
+    parent_branch : str, optional
+        The name of the parent branch from which the new branch will be created. Default is "main".
+
+    Returns
+    -------
+    str
+        The name of the newly created branch.
+    """
+    print(f"-> create_branch({repository}, {parent_branch})")
+
+    import random
+    import string
+
+    # Authenticate with GitHub
+    repo = get_github_repository(repository)
+
+    # Get the main branch
+    main_branch = repo.get_branch(parent_branch)
+
+    # Create a new branch
+    new_branch_name = "git-bob-mod-" + ''.join(random.choices(string.ascii_letters + string.digits, k=10))
+    repo.create_git_ref(ref=f"refs/heads/{new_branch_name}", sha=main_branch.commit.sha)
+
+    return new_branch_name
+
+
+def check_if_file_exists(repository, branch_name, file_path):
+    """
+    Checks if a specified file_path exists in a GitHub repository. Returns True if the file exists, False otherwise.
+
+    Parameters
+    ----------
+    repository : str
+        The full name of the GitHub repository (e.g., "username/repo-name").
+    branch_name: str
+        The name of the branch to check the file in.
+    file_path : str
+        The path of the file to check.
+
+    Returns
+    -------
+    bool
+        True if the file exists, False otherwise.
+    """
+    print(f"-> check_if_file_exists({repository}, {file_path})")
+
+    try:
+        # Try to get the contents of the file
+        get_file_in_repository(repository, branch_name, file_path)
+        return True
+    except:
+        return False
+
+
+def send_pull_request(repository, branch_name, title, description):
+    """
+    Create a pull request from a defined branch into the main branch.
+
+    Parameters
+    ----------
+    repository : str
+        The full name of the GitHub repository (e.g., "username/repo-name").
+    branch_name : str
+        The name of the branch that should be merged into main.
+    title : str
+        A one-liner explaining what was changed in the branch.
+    description : str
+        A more detailed description of what has happened.
+        If the changes are related to an issue write "closes #99 "
+        where 99 stands for the issue number the pull-request is related to.
+
+    Returns
+    -------
+    str
+        The URL to the pull-request that was just created.
+    """
+    print(f"-> send_pull_request({repository}, {branch_name}, ...)")
+
+    # Authenticate with GitHub
+    repo = get_github_repository(repository)
+
+    # Create a pull request
+    pr = repo.create_pull(title=title, body=description, head=branch_name, base="main")
+
+    return f"Pull request created: {pr.html_url}"

--- a/scripts/_github_utilities.py
+++ b/scripts/_github_utilities.py
@@ -1,3 +1,6 @@
+# This file contains utility functions using the github API via github-python:
+# https://github.com/PyGithub/PyGithub (licensed LGPL3)
+# Adapted from https://github.com/haesleinhuepf/git-bob/blob/main/src/git_bob/_github_utilities.py 
 import os
 from functools import lru_cache
 

--- a/scripts/auto-add-zenodo-entry.py
+++ b/scripts/auto-add-zenodo-entry.py
@@ -1,0 +1,81 @@
+# This script is executed when a new issue is created on our github repository. 
+# In case the issue text consists only of a single line starting like a zenodo link, 
+# it will retrieve all important details from the zenodo record, add it to a yml file
+# and send a pull-request
+import sys
+from _github_utilities import create_branch, get_file_in_repository, get_issue_body, write_file, send_pull_request
+import yaml
+
+
+def main():
+    repository = sys.argv[1]
+    issue = int(sys.argv[2])
+    
+    yml_filename = "resources/nfdi4bioimage.yml"
+    
+    
+    issue_text = get_issue_body(repository, issue)
+    if "\n" in issue_text or not issue_text.startswith("https://zenodo.org/records"):
+        print(issue_text, " is not a zenodo link. I show myself out.")
+        return
+
+    zenodo_url = issue_text
+    
+    # read data from zenodo
+    zenodo_data_dict = complete_zenodo_data(zenodo_url)
+    zenodo_yml = "- " + yaml.dump(zenodo_data_dict).replace("\n", "\n  ")
+
+    # read "database"
+    branch = create_branch(repository)
+    file_content = get_file_in_repository(repository, branch, yml_filename).decoded_content.decode()
+    
+    print("yml file content length:", len(file_content))
+
+    # add entry
+    file_content += zenodo_yml
+    file_content
+
+    # save back to github
+    write_file(repository, branch, yml_filename, file_content, "Add " + zenodo_url)
+    res = send_pull_request(repository, branch, "Add " + zenodo_url, f"closes #{issue}") 
+
+    print("Done.", res)
+    
+
+def complete_zenodo_data(zenodo_url):
+    from generate_link_lists import read_zenodo, remove_html_tags
+    zenodo_data = read_zenodo(zenodo_url)
+    entry = {}
+    urls = [zenodo_url]
+
+    if 'doi_url' in zenodo_data.keys():
+        doi_url = zenodo_data['doi_url']
+        
+        # Add DOI URL to the URLs list if it's not already there
+        if doi_url not in urls:
+            urls.append(doi_url)
+    entry['url'] = urls
+        
+    if 'metadata' in zenodo_data.keys():
+        metadata = zenodo_data['metadata']
+        # Update entry with Zenodo metadata and statistics
+        entry['name'] = metadata['title']
+        if 'publication_date' in metadata.keys():
+            entry['publication_date'] = metadata['publication_date']
+        if 'description' in metadata.keys():
+            entry['description'] = remove_html_tags(metadata['description'])
+        if 'creators' in metadata.keys():
+            creators = metadata['creators']
+            entry['authors'] = ", ".join([c['name'] for c in creators])
+        if 'license' in metadata.keys():
+            entry['license'] = metadata['license']['id']
+    
+    if 'stats'  in zenodo_data.keys():
+        entry['num_downloads'] = zenodo_data['stats']['downloads']
+
+    return entry
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
With this change, we install a github workflow that is executed when anyone creates a new github issue. If the issue contains only a single line of text that looks like a zenodo link (examples: #138 #136), this action will turn this zenodo link into a full record and send a pull-request. 

@SeverusYixin would you mind reviewing this PR? 

You can also test the script locally. You need a GITHUB_API_KEY environment variable and can call this from the repository root:
```
python scripts/auto-add-zenodo-entry.py NFDI4BIOIMAGE/training 138
```

It should then create a PR like #140 

Let me know what you think!

Thanks,
Robert

CC @marabuuu this should take some boring tasks off your shoulder. ☀️ 