### PR TITLE
Complete download statistics 

### DIFF
--- a/download_statistics/20240924.csv
+++ b/download_statistics/20240924.csv
@@ -1,0 +1,61 @@
+url,authors,downloads,unique_downloads,views,unique_views,version_downloads,version_unique_downloads,version_unique_views,version_views
+https://zenodo.org/records/11109616,"""Fuchs, Vanessa Aphaia Fiona and Schmidt, Christian and Boissonnet, Tom""",296,261,163,151,296,261,151,163
+https://zenodo.org/record/4071471,"""Biernacka, Katarzyna and Bierwirth, Maik and Buchholz, Petra and Dolzycka, Dominika and Helbig, Kerstin and Neumann, Janna and Odebrecht, Carolin and Wiljes, Cord and Wuttke, Ulrike""",4725,3638,5989,5401,4705,3621,5376,5963
+https://zenodo.org/record/3490058,"""Biernacka, Katarzyna and Cortez, Katrin and Helbig, Kerstin""",114,106,190,172,112,104,167,185
+https://zenodo.org/record/6602101,"""Della Chiesa, Stefano""",1140,740,913,751,306,216,181,221
+https://zenodo.org/records/8323588,"""Schmidt, Christian and Bortolomeazzi, Michele and Boissonnet, Tom and Fortmann-Grote, Carsten and Dohle, Julia and Zentis, Peter and Kandpal, Niraj and Kunis, Susanne and Zobel, Thomas and Weidtkamp-Peters, Stefanie and Ferrando-May, Elisa""",4165,3634,2487,2322,4165,3634,2322,2487
+https://zenodo.org/records/2643411,"""Stephen Royle""",107,103,790,759,107,103,757,788
+https://zenodo.org/records/4330625,"""Kreshuk, Anna and Kutra, Dominik""",41,39,102,94,41,39,94,102
+https://zenodo.org/records/4334697,"""Floden, Evan and Di Tommaso, Paolo""",80,79,63,61,80,79,61,63
+https://zenodo.org/records/4328911,"""Bankhead, Peter""",174,162,59,57,173,161,57,59
+https://zenodo.org/records/4317149,"""Jordan, Kari and Kamvar, Zhian and Hodges, Toby""",32,30,62,59,32,30,59,62
+https://zenodo.org/records/10083555,"""Wetzker, Cornelia""",90,71,128,123,90,71,123,128
+https://zenodo.org/records/10815329,"""Haase, Robert""",329,252,350,330,270,204,286,299
+https://zenodo.org/records/10679054,"""Fazeli, Elnaz""",160,131,236,227,160,131,227,236
+https://zenodo.org/records/10654775,"""Haase, Robert""",204,178,428,393,75,70,240,266
+https://zenodo.org/records/10008465,"""Moore, Josh""",99,65,131,126,99,65,126,131
+https://zenodo.org/records/10972692,"""Haase, Robert""",187,139,247,223,175,128,203,223
+https://zenodo.org/records/10990107,"""Haase, Robert""",165,118,240,224,148,103,186,199
+https://zenodo.org/records/10970869,"""Haase, Robert""",106,91,142,135,106,91,135,142
+https://zenodo.org/records/11066250,"""Haase, Robert""",104,87,95,86,98,81,72,80
+https://zenodo.org/records/11473803,"""Kemmer, Isabel and Euro-BioImaging ERIC""",180,137,217,195,180,137,195,217
+https://zenodo.org/records/11474407,"""Kemmer, Isabel and Euro-BioImaging ERIC""",127,101,163,152,127,101,152,163
+https://zenodo.org/records/11548617,"""Zoccoler, Marcelo and Bekemeier, Simon and Boissonnet, Tom and Parker, Simon and Bertinetti, Luca and Gentzel, Marc and Massei, Riccardo and Wetzker, Cornelia""",618,495,268,212,618,495,212,268
+https://zenodo.org/records/10687658,"""Moore, Josh and Waagmeester, Andra and Hettne, Kristina and Wolstencroft, Katherine and Kunis, Susanne""",110,88,176,160,110,88,160,176
+https://zenodo.org/records/8349562,"""Stöter, Torsten and Gottschall, Tobias and Schrader, Andrea and Zentis, Peter and Valencia-Schneider, Monica and Kandpal, Niraj and Zuschratter, Werner and Schauss, Astrid and Dickscheid, Timo and Mühlhaus, Timo and von Suchodoletz, Dirk""",177,141,276,252,171,135,247,271
+https://zenodo.org/records/8340247,"""Moore, Joshua Allen""",140,108,799,730,137,105,701,770
+https://zenodo.org/records/8139353,"""Weischer, Sarah and Wendt, Jens and Zobel, Thomas""",7,7,115,93,7,7,92,114
+https://zenodo.org/records/11109615,"""Fuchs, Vanessa Aphaia Fiona and Schmidt, Christian and Boissonnet, Tom""",296,261,163,151,296,261,151,163
+https://zenodo.org/records/10886749,"""Margineanu, Anca and Stringari, Chiara and Zoccoler, Marcelo and Wetzker, Cornelia""",182,147,188,177,182,147,177,188
+https://zenodo.org/records/10793699,"""Massei, Riccardo""",37,36,136,130,37,36,130,136
+https://zenodo.org/records/11265038,"""Pape, Constantin""",110,101,43,37,110,101,37,43
+https://zenodo.org/records/11107798,"""Voigt, Pia and Hundt, Carolin""",49,32,84,78,49,32,78,84
+https://zenodo.org/records/10942559,"""Della Chiesa, Stefano""",46,26,68,56,46,26,56,68
+https://zenodo.org/records/10816895,"""Haase, Robert""",79,67,100,94,79,67,94,100
+https://zenodo.org/records/4461261,"""Hesse, Elfi and Deinert, Jan-Christoph and Löschen, Christian""",288,260,527,505,285,257,503,525
+https://zenodo.org/records/11472148,"""Wünsche, Stephan""",52,40,107,103,52,40,103,107
+https://zenodo.org/records/11396199,"""Voigt, Pia""",54,49,108,105,54,49,105,108
+https://zenodo.org/records/4748510,"""Wünsche, Stephan and Voigt, Pia""",249,224,461,416,128,117,171,179
+https://zenodo.org/records/4630788,"""Voigt, Pia and Weiner, Barbara""",347,313,518,488,170,152,195,206
+https://zenodo.org/records/4748534,"""Voigt, Pia and Weiner, Barbara""",282,247,369,340,114,102,129,141
+https://zenodo.org/records/3778431,"""Weiner, Barbara and Wünsche, Stephan and Kühne, Stefan and Voigt, Pia and Frericks, Sebastian and Hoffmann, Clemens and Elze, Romy and Gey, Ronny""",1766,1475,2125,1803,1715,1440,1661,1954
+https://zenodo.org/records/12623730,"""Haase, Robert""",1589,1453,1247,1188,763,672,290,312
+https://zenodo.org/records/11201216,"""Hertweck, Kate and Strasser, Carly and Taraborelli, Dario""",1681,1457,1690,1557,1681,1457,1557,1690
+https://zenodo.org/records/12744715,"""Seibold, Heidi""",1415,1162,3895,3603,1415,1162,3603,3895
+https://zenodo.org/record/7018929,"""Kunis, Susanne""",42,31,127,120,42,31,118,125
+https://zenodo.org/records/8329306,"""Kunis, Susanne""",71,60,87,83,68,57,80,84
+https://zenodo.org/records/10008464,"""Moore, Josh""",99,65,131,126,99,65,126,131
+https://zenodo.org/records/10609770,"""Abdrabbou, Mohamed M. and Babaki, Mehrnaz and Boissonnet, Tom and Bortolomeazzi, Michele and Dahms, Eik and Fuchs, Vanessa A. F. and Hoevels, Moritz and Kandpal, Niraj and Möhl, Christoph and Moore, Joshua A. and Schauss, Astrid and Schrader, Andrea and Stöter, Torsten and Thönnißen, Julia and Valencia-S., Monica and Weil, H. Lukas and Wendt, Jens and Zentis, Peter""",5,5,148,129,3,3,101,107
+https://zenodo.org/records/11235512,"""Moore, Josh and Kunis, Susanne""",47,35,98,91,47,35,91,98
+https://zenodo.org/records/8329305,"""Kunis, Susanne""",71,60,87,83,68,57,80,84
+https://zenodo.org/records/7928332,"""Moore, Joshua Allenm and Kunis, Susanne""",109,62,83,75,107,61,74,82
+https://zenodo.org/records/8414318,"""Massei, Riccardo""",38,30,57,51,30,24,44,48
+https://zenodo.org/records/10730423,"""Fuchs, Vanessa Aphaia Fiona and Wendt, Jens and Müller, Maximilian and Ahmadi, Mohsen and Massei, Riccardo and Wetzker, Cornelia""",82,60,117,104,82,60,104,117
+https://zenodo.org/records/10939519,"""Schmidt, Christian""",44,36,43,39,44,36,39,43
+https://zenodo.org/records/11031746,"""Fortmann-Grote, Carsten""",71,54,94,91,71,54,91,94
+https://zenodo.org/records/13168693,"""Moore, Joshua and Kunis, Susanne and Grüning, Björn and Blank-Burian, Markus and Mallm, Jan-Philipp and Stöter, Torsten and Zuschratter, Werner and Figge, Marc Thilo and Kreshuk, Anna and Tischer, Christian and Haase, Robert and Zobel, Thomas and Bauer, Pavol and Svensson, Carl-Magnus and Gerst, Ruman and Hanne, Janina and Schmidt, Christian and Becker, Markus M. and Bocklitz, Thomas and Bumberger, Jan and Chalopin, Claire and Chen, Jianxu and Czodrowski, Paul and Dickscheid, Timo and Fortmann-Grote, Carsten and Huisken, Jan and Lohmann, Jan and Schauss, Astrid and Baumann, Martin and Beretta, Carlo and Burel, Jean-Marie and Heuveline, Vincent and Kuner, Rohini and Kuner, Thomas and Landwehr, Matthias and Leibfried, Andrea and Nitschke, Roland and Mittal, Deepti and von Suchodoletz, Dirk and Valencia-Schneider, Monica and Zentis, Peter and Brilhaus, Dominik and Hartley, Matthew and Hülsmann, Bastian and Dunker, Susanne and Keppler, Antje and Mathur, Aastha and Meesters, Christian and Möbius, Wiebke and Nahnsen, Sven and Pfander, Claudia and Rehwald, Stephanie and Serrano-Solano, Beatriz and Vilardell Scholten, Laura and Vogl, Raimund and Becks, Lutz and Ferrando-May, Elisa and Weidtkamp-Peters, Stefanie""",498,375,968,890,498,375,890,968
+https://zenodo.org/records/11318151,"""Moore, Josh""",20,15,50,47,20,15,47,50
+https://zenodo.org/records/11521029,"""Geiger, Jonathan and Steiner, Petra and Desouki, Abdelmoneim Amer and Lange, Frank""",646,498,885,817,646,498,817,885
+https://zenodo.org/records/13379394,"""Haase, Robert""",407,305,327,303,392,293,274,296
+https://zenodo.org/records/13371196,"""Haase, Robert""",486,344,359,300,290,203,159,189
+https://zenodo.org/records/13506641,"""Haase, Robert""",192,161,210,198,140,119,120,124

--- a/scripts/auto-add-download-statistics.py
+++ b/scripts/auto-add-download-statistics.py
@@ -44,6 +44,7 @@ def summarize_download_statistics(directory_path):
     import os
     from pathlib import Path
     import datetime
+    import re
 
     #collect all content in a list of dictionaries
     content = all_content(directory_path) 
@@ -54,13 +55,21 @@ def summarize_download_statistics(directory_path):
     for entry in content['resources']:
         urls = entry['url']
 
-        #make urls a list if it is not already
-        if not type(urls) is list:
-                urls = [urls]
-        
+        # Ensure 'urls' is a list
+        if not isinstance(urls, list):
+            urls = [urls]
+
         for url in urls:
-            # if zenodo in url
+            # If 'zenodo.org' is in the URL
             if 'zenodo.org' in url:
+                # Check if it's a DOI-based URL
+                if 'doi' in url:
+                    # Extract the Zenodo record ID from the DOI
+                    match = re.search(r'zenodo\.(\d+)', url)
+                    if match:
+                        record_id = match.group(1)
+                        # Change the URL to 'records' format
+                        url = f"https://zenodo.org/records/{record_id}"
 
                 #extract meta data of records in zenodo
                 zenodo = read_zenodo(url)

--- a/scripts/summary_download_statistics.py
+++ b/scripts/summary_download_statistics.py
@@ -8,6 +8,7 @@ import pandas as pd
 import os
 from pathlib import Path
 import datetime
+import re
 
 #define directory path
 directory_path = './resources/'
@@ -27,13 +28,21 @@ download_statistics = pd.DataFrame()
 for entry in content['resources']:
     urls = entry['url']
 
-    #make urls a list if it is not already
-    if not type(urls) is list:
-            urls = [urls]
-    
+    # Ensure 'urls' is a list
+    if not isinstance(urls, list):
+        urls = [urls]
+
     for url in urls:
-        # if zenodo in url
+        # If 'zenodo.org' is in the URL
         if 'zenodo.org' in url:
+            # Check if it's a DOI-based URL
+            if 'doi' in url:
+                # Extract the Zenodo record ID from the DOI
+                match = re.search(r'zenodo\.(\d+)', url)
+                if match:
+                    record_id = match.group(1)
+                    # Change the URL to 'records' format
+                    url = f"https://zenodo.org/records/{record_id}"
 
             #extract meta data of records in zenodo
             zenodo = read_zenodo(url)


### PR DESCRIPTION
Hi @haesleinhuepf, 

This PR closes #208.

The reason why only part of the zenodo urls were taken into account was because[ `read_zenodo` ](https://github.com/NFDI4BIOIMAGE/training/blob/c8ef954d874e7452bad245131bfc34cb62fbe6c9/scripts/generate_link_lists.py#L286)function expects an url like this:

`https://zenodo.org/record(s)/`

and the urls that were not taken into account in the dataframe were structured like this:

`https//zenodo.org/doi/`

Therefore, I have modified the script in the way that all doi-based urls are converted to record-based urls. I have not modified the `read_zenodo` function itself as I didn't know if it would impact other parts of the repo.

One link that is still not appearing in the dataframe is structured like this
`https://zenodo.org/communities/`

I did not include it as it links to several zenodo entries.

I have committed also the resulting csv-file.

Let me know if I should make any changes and I am happy to do so. 

Best,
Mara

