### PR TITLE
Domains as category

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -22,6 +22,9 @@ parts:
     chapters:
 {license_toc}
 
+  - caption: By domain
+{domain_toc}
+
     # when adding new chapters here, don't forget to also add them to the scipts/generate_link_lists.py file
 
     

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -23,6 +23,7 @@ parts:
 {license_toc}
 
   - caption: By domain
+    chapters:
 {domain_toc}
 
     # when adding new chapters here, don't forget to also add them to the scipts/generate_link_lists.py file

--- a/scripts/generate_link_lists.py
+++ b/scripts/generate_link_lists.py
@@ -23,7 +23,7 @@ def main():
     for domain in sorted(list(all_domain_counts.keys())):
         count = all_domain_counts[domain]
         if count >= MINIMUM_ITEM_COUNT:
-            selected_content = find_tag(content, domain)
+            selected_content = find_domain(content, domain)
             filename = "domain/" + domain.replace(" ", "_")
             write_md(selected_content, domain, "docs/" + filename + ".md")
             domain_toc += "    - file: " + filename + "\n"
@@ -366,6 +366,10 @@ def find_type(content, content_type):
 def find_tag(content, tag):
     """Takes a dictionary of resources, searches for resources which have a given tag and returns them as new dictionary."""
     return find_anything(content, "tags", tag)
+
+def find_domain(content, tag):
+    """Takes a dictionary of resources, searches for resources which have a given domain and returns them as new dictionary."""
+    return find_anything(content, "domain", tag)
 
 def find_anything(content, what_to_look_in, what_to_find):
     """

--- a/scripts/generate_link_lists.py
+++ b/scripts/generate_link_lists.py
@@ -25,7 +25,7 @@ def main():
         if count >= MINIMUM_ITEM_COUNT:
             selected_content = find_tag(content, domain)
             filename = "domain/" + domain.replace(" ", "_")
-            write_md(selected_content, domain, "domain/" + filename + ".md")
+            write_md(selected_content, domain, "docs/" + filename + ".md")
             domain_toc += "    - file: " + filename + "\n"
     replace_in_file(toc_file, "{domain_toc}", domain_toc)
 


### PR DESCRIPTION
With this PR I am adding a new category "domain" to our meta-data, computed  dynamically from given URLs. It allows us to filter for all records that are stored on zenodo.org or github.com:

![image](https://github.com/user-attachments/assets/f08a192c-863e-4c11-b0b8-4eef303bb7d4)

@SeverusYixin would you mind reviewing my code modifications - as quality assurance procedure?

Thanks!