### PR TITLE
Correct display of author lists

### DIFF
--- a/scripts/generate_link_lists.py
+++ b/scripts/generate_link_lists.py
@@ -398,6 +398,8 @@ def write_md(resources, title, filename):
             file.write("## " + name + '\n')
             if 'authors' in properties:
                 authors = properties['authors']
+                if isinstance(authors, list):
+                    authors = ", ".join(authors)
                 file.write(f"\n{authors}\n")
             if 'publication_date' in properties:
                 publication_date = properties['publication_date']


### PR DESCRIPTION
This fixes the display of author lists on our website. This is how it looked before:

![image](https://github.com/user-attachments/assets/f0178311-a682-4cff-8118-0ee2236728da)

This is how it looks after this code modification:

![image](https://github.com/user-attachments/assets/ea711a28-f085-4b36-99ea-6f402958c455)
