### PR TITLE
Format the author as a multi-line list_Zenodo

### DIFF
--- a/scripts/auto-add-zenodo-entry.py
+++ b/scripts/auto-add-zenodo-entry.py
@@ -93,7 +93,7 @@ def complete_zenodo_data(zenodo_url):
             entry['description'] = remove_html_tags(metadata['description'])
         if 'creators' in metadata.keys():
             creators = metadata['creators']
-            entry['authors'] = ", ".join([c['name'] for c in creators])
+            entry['authors'] = [c['name'] for c in creators]
         if 'license' in metadata.keys():
             entry['license'] = metadata['license']['id']
     


### PR DESCRIPTION
Format the author field as a multi-line list to assist data_normalizer.py in recognizing and normalizing authors' names more effectively.

This PR solved problem: https://github.com/NFDI4BIOIMAGE/training/blob/089c26a86a6625499809be0955ce58977251a757/resources/nfdi4bioimage.yml#L6935

This PR related to #512 
This PR closes #512 