### PR TITLE
remove repository that was deleted

### DIFF
--- a/resources/nfdi4bioimage.yml
+++ b/resources/nfdi4bioimage.yml
@@ -11035,16 +11035,6 @@ resources:
   url: https://github.com/bioimage-io/bioimageio-chatbot
  
 
-- authors:
-  - Jean-Yves Tinevez
-  description: Teaching materials and outline for the Pasteur Bioimage Analysis vour
-  name: Pasteur-BioImage-Analysis-Course-2025
-  publication_date: '2025-04-10T13:26:22+00:00'
-  submission_date: '2025-04-10T15:06:24.589294'
-  tags: 
-  - bioimage analysis
-  type: GitHub Repository
-  url: https://github.com/Image-Analysis-Hub/Pasteur-BioImage-Analysis-Course-2025
 
 - authors:
   - Rensu Petrus Theart


### PR DESCRIPTION
Here I'm removing a repository from our training material collection, because it was deleted aparently. 

If the Training materials for the Pasteur NEUBIAS course were published elsewhere, please open an issue and let us know. @tinevez @StRigaud 

Thanks!