### PR TITLE
Added JIPipe Workshop (JSC2025)

### DIFF
--- a/resources/nfdi4bioimage.yml
+++ b/resources/nfdi4bioimage.yml
@@ -11185,6 +11185,30 @@ resources:
   type: GitHub Repository
   url: https://github.com/fefossa/2023_CourseImageAnalysis_NanoCell
 
+- authors:
+  - Ruman Gerst
+  - Zoltán Cseresnyés
+  - Marc Thilo Figge
+  name: 'JIPipe Spring Course (JSC) 2025: Workshop Recordings, Slides, Homework, and Materials'
+  description: 'The course gives a basic introduction into microscopy, optics, and image analysis. 
+  This is followed by interactive tutorials that explain the basics of creating fully automated image analysis 
+  workflows in JIPipe using a simple blobs analysis and intermediate-level quantification of LSFM kidney images. 
+  JIPipe-specific features including annotation-guided batch processing, organization with graph compartments, 
+  expressions and path processing, and project-wide metadata and parameters are also established. 
+  Finally, an advanced real-world pipeline is showcased with detailed guidance through the individual 
+  components that include integrations of Cellpose and TrackMate.'
+  url: 'https://doi.org/10.5281/zenodo.15373555'
+  type:
+  - Workshop
+  - Video
+  - Tutorial
+  - Slides
+  license: cc-by-4.0
+  publication_date: '2025-05-12:T13:37:00+00:00'
+  tags:
+  - jipipe
+  - bioimage analysis
+
 
 
   


### PR DESCRIPTION
Added an entry for the JIPipe workshop 31.03.2025-04.04.2025.

Contains:

- Edited recordings (suitable as tutorial)
- Slides
- Example workflows
- Homework + Solution